### PR TITLE
Fixes and features

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,83 +25,83 @@ Inputs:
 
 -t|--top-directory
 
-where fs-drift puts all its files.  Since the design center for fs-drift is distributed filesystems, we don't support multiple top-level directories.  However, you can run multiple instances of fs-drift with different top-level directories and aggregate the results yourself.
+where fs-drift puts all its files.  Since the design center for fs-drift is distributed filesystems, we don't support multiple top-level directories.  However, you can run multiple instances of fs-drift with different top-level directories and aggregate the results yourself.(default '/tmp/foo')
 
 -S|--starting-gun-file
 
-When run in distributed mode, fs-drift processes wait until they see this file before the run actually starts.  This allows fs-drift to synchronize start and stop of testing across systems, crucial for result aggregation across processes.
+When run in distributed mode, fs-drift processes wait until they see this file before the run actually starts.  This allows fs-drift to synchronize start and stop of testing across systems, crucial for result aggregation across processes.(default None)
 
 -o|--operation-count
 
-How many operations fs-drift should attempt.  Note that this includes operations that abort with an expected system call error, such as create of a file that already exists.
+How many operations fs-drift should attempt.  Note that this includes operations that abort with an expected system call error, such as create of a file that already exists.(default 0)
 
 -d|--duration
 
-Generally it's best to specify test duration in seconds instead of operation count.
+Generally it's best to specify test duration in seconds instead of operation count.(default 1)
 
 -f|--max-files
 
-Set a limit on the maximum number of files that can be accessed by fs-drift.  This allows us to run tests where we use a small fraction of the filesystem's space.  To fill up a filesystem, just specify a --max-files and a mean file size such that the product is much greater than the filesystem's space.
+Set a limit on the maximum number of files that can be accessed by fs-drift.  This allows us to run tests where we use a small fraction of the filesystem's space.  To fill up a filesystem, just specify a --max-files and a mean file size such that the product is much greater than the filesystem's space.(default 20)
 
 -s|--max-file-size-kb
 
-Set a limit on maximum file size in KB.  File size is randomly generated and can be much less than this.
+Set a limit on maximum file size in KB.  File size is randomly generated and can be much less than this.(default 10)
 
 -r|--max-record-size-kb
 
-Set a limit on maximum record size in KB.  Record (I/O transfer) size is randomly generated and can be much less than this.
+Set a limit on maximum record size in KB.  Record (I/O transfer) size is randomly generated and can be much less than this.(default 1)
 
 -R|--max-random-reads
 
-Set a limit on how many random reads in a row are done to a file per random read op.
+Set a limit on how many random reads in a row are done to a file per random read op.(default 2)
 
 -W|--max-random-writes
 
-Set a limit on how many random writes in a row can be done to a file per random write op.
+Set a limit on how many random writes in a row can be done to a file per random write op.(default 2)
 
 -Y|--fsyncs
 
-If true, allows fsync() call to be done every so often when files are written.
+If true, allows fsync() call to be done every so often when files are written. Value is probability in percent. (default 20)
 
 -y|--fdatasyncs
 
-If true, allows fdatasync() call to be done every so often when files are written.
+If true, allows fdatasync() call to be done every so often when files are written. Value is probability in percent. (default 10)
 
 -T|--response-times
 
-If true, save response time data to a .csv file.
+If true, save response time data to a .csv file. (default False)
 
 -l|--levels
 
-How many directory levels will be used.
+How many directory levels will be used. (default 2)
 
 -D|--dirs-per-level
 
-How many directories per level will be used.
+How many directories per level will be used. (default 3)
 
 -w|--workload-table
 
-Provide a user-specified workload table controlling the mix of random operations.
+Provide a user-specified workload table controlling the mix of random operations.(default None)
 
 -i|--report-interval
 
-Report counters over a user-specified interval.
+Report counters over a user-specified interval. (default 0)
 
 -+D|--random-distribution
 
-By default, filename access frequency is random uniform, but with this parameter set to "gaussian" you can create a non-uniform distribution of file access.  This is useful for caching and cache tiering systems.
+By default, filename access frequency is random uniform, but with this parameter set to "gaussian" you can create a non-uniform distribution of file access.  This is useful for caching and cache tiering systems. (default 'uniform')
 
 -+v|--mean-velocity
 
-By default, a non-uniform random filename distribution is stationary over time, but with this parameter you can make the mean "move" at a specified velocity (i.e. the file number mean will shift by this much for every operation, modulo the maximum number of files.  
+By default, a non-uniform random filename distribution is stationary over time, but with this parameter you can make the mean "move" at a specified velocity (i.e. the file number mean will shift by this much for every operation, modulo the maximum number of files. (default 0.0)
 
 -+d|--gaussian-stddev
 
-For gaussian filename distribution, this parameter controls with width of the bell curve.  As you increase this parameter past the cache space in your caching layer, the probability of a cache hit will go down.
+For gaussian filename distribution, this parameter controls with width of the bell curve.  As you increase this parameter past the cache space in your caching layer, the probability of a cache hit will go down. (default 1000.0)
 
 -+c|--create_stddevs-ahead
 
-This parameter is for cache tiering testing.  It allows creates to "lead" all other operations, so that we can create a high probability that read files will be in the set of "hot files".  Otherwise, most read accesses with non-uniform filename distribution will result  in "file not found" errors.
+This parameter is for cache tiering testing.  It allows creates to "lead" all other operations, so that we can create a high probability that read files will be in the set of "hot files".  Otherwise, most read accesses with non-uniform filename distribution will result  in "file not found" errors. (default 3.0)
 
 
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If true, allows fdatasync() call to be done every so often when files are writte
 
 -T|--response-times
 
-If true, save response time data to a .csv file. (default False)
+If true, save response time data to a .csv file. First value is number of seaconds after start of the test. Second value is number of seconds the operation lasted. Response times for different operations are separated. (default False)
 
 -l|--levels
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ For gaussian filename distribution, this parameter controls with width of the be
 
 This parameter is for cache tiering testing.  It allows creates to "lead" all other operations, so that we can create a high probability that read files will be in the set of "hot files".  Otherwise, most read accesses with non-uniform filename distribution will result  in "file not found" errors. (default 3.0)
 
+-p|--pause
+
+Parameter allows to specify pause file. If this file exists, fs-drift won't perform any I/O operations. (default /var/tmp/pause)
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If true, allows fsync() call to be done every so often when files are written.
 
 If true, allows fdatasync() call to be done every so often when files are written.
 
--r|--response-times
+-T|--response-times
 
 If true, save response time data to a .csv file.
 

--- a/fs-drift.py
+++ b/fs-drift.py
@@ -123,6 +123,12 @@ start_time = time.time()
 event_count = 0
 
 while True:
+        #if there is pause file present, do nothing
+
+        if os.path.isfile(opts.pause_file):
+                time.sleep(5)
+                continue
+
         # every 1000 events, check for "stop file" that indicates test should end
 
 	event_count += 1

--- a/fs-drift.py
+++ b/fs-drift.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # fs-drift.py - user runs this module to generate workload
 # "-h" option generates online help

--- a/fs-drift.py
+++ b/fs-drift.py
@@ -148,10 +148,12 @@ while True:
 		print x, name
 	before = time.time()
         before_drift = time.time()
+        curr_e_exists, curr_e_not_found = fsop.e_already_exists, fsop.e_file_not_found
 	try:
 		rc = fn()
 		after = time.time()
-		rsptimes.append((before - start_time, after - before))
+		if curr_e_exists == fsop.e_already_exists and curr_e_not_found == fsop.e_file_not_found:
+		        rsptimes.append((before - start_time, after - before))
 	except KeyboardInterrupt, e:
 		print "received SIGINT (control-C) signal, aborting..."
 		break

--- a/fs-drift.py
+++ b/fs-drift.py
@@ -107,7 +107,7 @@ os.chdir(opts.top_directory)
 sys.stdout.flush()
 
 op = 0
-rsptimes = []
+rsptimes = {'read':[], 'random_read': [], 'create':[], 'random_write':[], 'append':[], 'link':[], 'delete':[], 'rename':[], 'truncate':[], 'hardlink':[]}
 last_stat_time = time.time()
 last_drift_time = time.time()
 stop_file = opts.top_directory + os.sep + 'stop-file'
@@ -153,7 +153,7 @@ while True:
 		rc = fn()
 		after = time.time()
 		if curr_e_exists == fsop.e_already_exists and curr_e_not_found == fsop.e_file_not_found:
-		        rsptimes.append((before - start_time, after - before))
+		        rsptimes[name].append((before - start_time, after - before))
 	except KeyboardInterrupt, e:
 		print "received SIGINT (control-C) signal, aborting..."
 		break

--- a/fs-drift.py
+++ b/fs-drift.py
@@ -171,8 +171,10 @@ while True:
 		last_drift_time = before_drift
 
 if opts.rsptimes:
-	for (reltime, rspt) in rsptimes:
-		rsptime_file.write('%9.3f , %9.6f\n'%(reltime,  rspt))
+	for key, ls in rsptimes.items():
+		rsptime_file.write(key+'\n')	
+		for (reltime, rspt) in ls:
+			rsptime_file.write('%9.3f , %9.6f\n'%(reltime,  rspt))	
 	rsptime_file.close()
 	print 'response time file is %s'%rsptime_filename
 

--- a/fsop.py
+++ b/fsop.py
@@ -450,11 +450,11 @@ def delete():
 			if verbosity & 0x20000:
                                 print 'delete soft link %s'%(linkfn)
 			os.unlink(linkfn)
-                else:
-                        linkfn = fn + hlink_suffix
+		hlinkfn = fn + hlink_suffix
+		if os.path.isfile(hlinkfn):
 			if verbosity & 0x20000:
-                                print 'delete hard link %s'%(linkfn)
-			os.unlink(linkfn)
+                                print 'delete hard link %s'%(hlinkfn)
+			os.unlink(hlinkfn)
 		os.unlink(fn)
 		have_deleted += 1
 	except os.error, e:

--- a/opts.py
+++ b/opts.py
@@ -33,6 +33,7 @@ def usage(msg):
         print '-+v|--mean-velocity'
         print '-+d|--gaussian-stddev'
         print '-+c|--create_stddevs-ahead'
+        print '-p|--pause_file'
 	sys.exit(NOTOK)
 
 # command line parameter variables here
@@ -61,6 +62,7 @@ mean_index_velocity = 0.0 # default is a fixed mean for the distribution
 gaussian_stddev = 1000.0  # just a guess, means most of accesses within 1000 files?
 create_stddevs_ahead = 3.0 # just a guess, most files will be created before they are read
 drift_time = -1
+pause_file='/var/tmp/pause'
 
 def parseopts():
 	global top_directory, starting_gun_file, opcount, max_files, max_file_size_kb, duration, short_stats
@@ -127,6 +129,8 @@ def parseopts():
 			gaussian_stddev = float(val)
                 elif nm == '--create_stddevs-ahead' or nm == '-+c':
                         create_stddevs_ahead = float(val)
+		elif nm == '--pause_file' or nm == '-p':
+                        pause_file = val
 		else:
 			usage('syntax error for option %s value %s'%(nm, val))
 	except Exception, e:

--- a/opts.py
+++ b/opts.py
@@ -23,7 +23,7 @@ def usage(msg):
 	print '-W|--max-random-writes'
 	print '-Y|--fsyncs'
 	print '-y|--fdatasyncs'
-	print '-r|--response-times'
+	print '-T|--response-times'
 	print '-l|--levels'
 	print '-D|--dirs-per-level'
 	print '-w|--workload-table'


### PR DESCRIPTION
Fixed invalid response-times options from '-r' to valid '-T'
Fixed main script shebang to use python3. (on most systems, default is still python2)

Fixed issue in delete() function. The function tries to remove soft link, then hard link. Removing of regular file is bypassed.

Signed-off-by: Samuel Petrovic <spetrovi@redhat.com>