### PR TITLE
Include fsync into perf measurement

### DIFF
--- a/fsop.py
+++ b/fsop.py
@@ -345,8 +345,8 @@ def create():
             total_sz += count
             write_requests += 1
             write_bytes += count
-        time_after = time.time()
         maybe_fsync(fd)
+        time_after = time.time()
         have_created += 1
     except os.error as e:
         if e.errno == errno.EEXIST:
@@ -391,8 +391,8 @@ def append():
             total_appended += count
             write_requests += 1
             write_bytes += count
-        time_after = time.time()
         maybe_fsync(fd)
+        time_after = time.time()
         have_appended += 1
     except os.error as e:
         if e.errno == errno.ENOENT:
@@ -443,8 +443,8 @@ def random_write():
             total_write_reqs += 1
             randwrite_requests += 1
             randwrite_bytes += total_count
-        time_after = time.time()
         maybe_fsync(fd)
+        time_after = time.time()
         have_randomly_written += 1
     except os.error as e:
         if e.errno == errno.ENOENT:

--- a/fsop.py
+++ b/fsop.py
@@ -269,7 +269,7 @@ def random_read():
                 if recsz + total_count > remaining_sz:
                     recsz = remaining_sz - total_count
                 elif recsz + total_count > targetsz:
-                    recsz = rdsz - total_count
+                    recsz = targetsz - total_count
                 if recsz == 0:
                     break
                 bytebuf = os.read(fd, recsz)


### PR DESCRIPTION
As discussed, we actually want to include fsync into the performance measurement, as it can have significant impact on validity of measured data.

Moving maybe_fsync on a line before time log event