### PR TITLE
Fix error: E101 indentation contains mixed spaces and tabs

### DIFF
--- a/rsptime_stats.py
+++ b/rsptime_stats.py
@@ -113,7 +113,7 @@ def reduce_thread_set( sorted_samples_tuple, from_time=0, to_time=time_infinity 
         sorted_times = sorted(map(get_rsp_time, sorted_samples[start_index:end_index]))
     sample_count = len(sorted_times)
     if sample_count < min_rsptime_samples:
-	return None
+        return None
     mintime = sorted_times[0]
     maxtime = sorted_times[-1]
     mean = scipy.stats.tmean(sorted_times)
@@ -129,7 +129,7 @@ def reduce_thread_set( sorted_samples_tuple, from_time=0, to_time=time_infinity 
 
 def format_stats(all_stats):
     if all_stats == None:
-	return ' 0,,,,,' + ',,,,,,,,,,,,,,,,'[0:len(percentiles)-1]
+        return ' 0,,,,,' + ',,,,,,,,,,,,,,,,'[0:len(percentiles)-1]
     (sample_count, mintime, maxtime, mean, pctdev, pctiles) = all_stats
     partial_record = '%d, %f, %f, %f, %f, ' % (
             sample_count, mintime, maxtime, mean, pctdev)
@@ -284,7 +284,7 @@ with open(summary_pathname, 'w') as outf:
         for t in threadset.keys():
             (_, samples) = threadset[t]
             if len(samples) > 0:
-            	(_, max_at_time,max_rsp_time) = samples[-1]
+                (_, max_at_time,max_rsp_time) = samples[-1]
             else:
                 max_at_time = 0.0
                 max_rsp_time = 0.0


### PR DESCRIPTION
I found out that the file `rsptime_stats.py` had several tabs rather than spaces in some lines. This issue crashes on python3.

```shell
$ python3 rsptime_stats.py 
  File "rsptime_stats.py", line 116
    return None
              ^
TabError: inconsistent use of tabs and spaces in indentation
$  flake8 rsptime_stats.py  | grep E101                                                                                                                                   
rsptime_stats.py:116:1: E101 indentation contains mixed spaces and tabs
rsptime_stats.py:117:1: E101 indentation contains mixed spaces and tabs
rsptime_stats.py:132:1: E101 indentation contains mixed spaces and tabs
rsptime_stats.py:133:1: E101 indentation contains mixed spaces and tabs
rsptime_stats.py:287:13: E101 indentation contains mixed spaces and tabs
```