### PR TITLE
Python3 fixes

### DIFF
--- a/rsptime_stats.py
+++ b/rsptime_stats.py
@@ -78,7 +78,7 @@ def do_sorting(sample_set, already_sorted=False):
         sorted_samples = sorted(sample_set, key=get_at_time)
     else:
         sorted_samples = sample_set
-    sorted_keys = map(get_at_time, sorted_samples)
+    sorted_keys = list(map(get_at_time, sorted_samples))
     sorted_rsptimes = sorted(map(get_rsp_time, sample_set))
     return (sorted_samples, sorted_keys, sorted_rsptimes)
 
@@ -249,7 +249,7 @@ with open(summary_pathname, 'w') as outf:
     # if there is only 1 thread per host, no need for per-host stats
     # assumption: all hosts have 1 thread/host or all hosts have > 1 thread/host
 
-    first_host = hosts[hosts.keys()[0]]
+    first_host = hosts[list(hosts.keys())[0]]
     if len(first_host.keys()) > 1:
         outf.write('per-host stats:\n')
         for h in sorted(hosts.keys()):


### PR DESCRIPTION
These fixes make the `rsptime_stats.py` script able to work on python3.

TypeError: 'dict_keys' object does not support indexing
```
sh-4.4$ python3 rsptime_stats.py --time-interval 1 /tmp/fs_drift_test_data/network-shared
time interval is 1 seconds
Traceback (most recent call last):
  File "/usr/local/bin/rsptime_stats.py", line 252, in <module>
    first_host = hosts[hosts.keys()[0]]
TypeError: 'dict_keys' object does not support indexing
```

 
TypeError: object of type 'map' has no len()
```
sh-4.4$ python3 rsptime_stats.py --time-interval 1 /tmp/fs_drift_test_data/network-shared
Traceback (most recent call last):                                                                       
  File "/usr/local/bin/rsptime_stats.py", line 315, in <module>                                          
    to_time=to_t)                                                                                        
  File "/usr/local/bin/rsptime_stats.py", line 110, in reduce_thread_set
    start_index = find_le(sorted_keys, from_time)                                                        
  File "/usr/local/bin/rsptime_stats.py", line 91, in find_le                                            
    i = bisect.bisect_right(a, x)                                                                                                                                                                                  
TypeError: object of type 'map' has no len()  
```


