### PR TITLE
[Feature] rawdevice

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ Default: 85 - Because fs-drift depends on the filesystem under test to return re
 
 Default: False -- If True, fs-drift will use flag O_DIRECT when opening files. All the issued IOs will be alligned to 4KB, i.e. record size and file size smaller than 4KB will be upscaled to 4KB.
 
+--rawdevice
+
+Default: None -- If set, fs-drift will use provided block device for raw device testing, i.e. all IOs will be issued directly to the device. Warning, testing a device like this WILL corrupt any data or file systems present on the device. Always make sure, there is nothing valuable present on the provided device.
+
 ## future enhancements
 
 - logging - is a bit chaotic, done differently in different places, too many log files,

--- a/fsop.py
+++ b/fsop.py
@@ -583,6 +583,8 @@ class FSOPCtx:
 
 
     def op_truncate(self):
+        if self.params.rawdevice != None:
+            return OK
         c = self.ctrs
         fd = FD_UNDEFINED
         s = OK
@@ -613,6 +615,8 @@ class FSOPCtx:
 
 
     def op_softlink(self):
+        if self.params.rawdevice != None:
+            return OK    
         if self.fs_is_full():
             self.log.debug('filesystem full, disabling softlink')
             return OK
@@ -643,6 +647,8 @@ class FSOPCtx:
 
 
     def op_hardlink(self):
+        if self.params.rawdevice != None:
+            return OK    
         if self.fs_is_full():
             self.log.debug('filesystem full, disabling hardlink')
             return OK
@@ -673,6 +679,8 @@ class FSOPCtx:
 
 
     def op_delete(self):
+        if self.params.rawdevice != None:
+            return OK    
         c = self.ctrs
         fn = self.gen_random_fn()
         if self.verbosity & 0x20000:
@@ -708,6 +716,8 @@ class FSOPCtx:
 
 
     def op_rename(self):
+        if self.params.rawdevice != None:
+            return OK    
         c = self.ctrs
         fn = self.gen_random_fn()
         fn2 = self.gen_random_fn()
@@ -737,6 +747,8 @@ class FSOPCtx:
     # assumption: mountpoint comes last on the mount command
     
     def op_remount(self):
+        if self.params.rawdevice != None:
+            return OK    
         c = self.ctrs
         if self.params.mount_command == None:
             raise FsDriftException('you did not specify mount command for remount option')
@@ -770,6 +782,8 @@ class FSOPCtx:
         return OK
 
     def op_readdir(self):
+        if self.params.rawdevice != None:
+            return OK    
         c = self.ctrs
         fn = self.gen_random_fn()
         dirpath = os.path.dirname(fn)

--- a/opts.py
+++ b/opts.py
@@ -50,6 +50,7 @@ class FsDriftOpts:
         self.pause_secs = self.pause_between_ops / float(USEC_PER_SEC)
         self.incompressible = False
         self.directIO = False
+        self.rawdevice = None
         # new parameters related to gaussian filename distribution
         self.random_distribution = FileAccessDistr.uniform
         self.mean_index_velocity = 1.0  # default is a fixed mean for the distribution
@@ -94,6 +95,7 @@ class FsDriftOpts:
             ('subdirectories per directory', self.subdirs_per_dir),
             ('incompressible data', self.incompressible),
             ('use direct IO', self.directIO),            
+            ('use this device for raw IO', self.rawdevice),                      
             ('pause between ops (usec)', self.pause_between_ops),
             ('distribution', FileAccessDistr2str(self.random_distribution)),
             ('mean index velocity', self.mean_index_velocity),
@@ -217,6 +219,8 @@ def parseopts(cli_params=sys.argv[1:]):
     add('--directIO', help='if True then use directIO to open files/device',
             type=boolean,
             default=o.directIO)            
+    add('--rawdevice', help='if set, use this device as a target for rawdevice testing (Warning: Data/File systems on this device will be corrupted)',
+            default=o.rawdevice)                
     add('--random-distribution', help='either "uniform" or "gaussian"',
             type=file_access_distrib, 
             default=FileAccessDistr.uniform)
@@ -266,6 +270,7 @@ def parseopts(cli_params=sys.argv[1:]):
     o.subdirs_per_dir = args.dirs_per_level
     o.incompressible = args.incompressible
     o.directIO = args.directIO    
+    o.rawdevice = args.rawdevice        
     o.pause_between_ops = args.pause_between_ops
     o.pause_secs = o.pause_between_ops / float(USEC_PER_SEC)
     o.response_times = args.response_times
@@ -365,6 +370,8 @@ def parse_yaml(options, input_yaml_file):
                 options.incompressible = boolean(v)
             elif k == 'directIO':
                 options.directIO = boolean(v)                
+            elif k == 'rawdevice':
+                options.rawdevice = v                    
             elif k == 'random_distribution':
                 options.random_distribution = file_access_distrib(v)
             elif k == 'mean_velocity':
@@ -431,7 +438,8 @@ if __name__ == "__main__":
             params.extend(['--report-interval', '60'])
             params.extend(['--response-times', 'Y'])
             params.extend(['--incompressible', 'false'])
-            params.extend(['--directIO', 'false'])            
+            params.extend(['--directIO', 'false'])      
+            params.extend(['--rawdevice', 'none'])                   
             params.extend(['--random-distribution', 'gaussian'])
             params.extend(['--mean-velocity', '4.2'])
             params.extend(['--gaussian-stddev', '100.2'])
@@ -499,6 +507,7 @@ if __name__ == "__main__":
             assert(p.rsptimes == True)
             assert(p.incompressible == False)
             assert(p.directIO == False)            
+            assert(p.rawdevice == None)            
             assert(p.random_distribution == FileAccessDistr.gaussian)
             assert(p.mean_velocity == 4.2)
             assert(p.gaussian_stddev == 100.2)

--- a/worker_thread.py
+++ b/worker_thread.py
@@ -270,6 +270,8 @@ class FsDriftWorkload:
         self.end_time = time.time()
         self.elapsed_time = self.end_time - self.start_time
         if self.elapsed_time > self.params.duration:
+            #In case of rawdevice testing, close file
+            os.close(self.ctx.rawdevice_fd)
             # must be fixed-length string so we can compute threads done from file size
             elapsed_time_str = self.thread_done_record()
             try:

--- a/worker_thread.py
+++ b/worker_thread.py
@@ -271,7 +271,8 @@ class FsDriftWorkload:
         self.elapsed_time = self.end_time - self.start_time
         if self.elapsed_time > self.params.duration:
             #In case of rawdevice testing, close file
-            os.close(self.ctx.rawdevice_fd)
+            if self.params.rawdevice != None:
+                os.close(self.ctx.rawdevice_fd)
             # must be fixed-length string so we can compute threads done from file size
             elapsed_time_str = self.thread_done_record()
             try:


### PR DESCRIPTION
Sometimes, we're interested only in performance of the layer being currently researched, so file system isn’t needed while testing.
This doesn't change much of the benchmark's usability. User just specifies

--rawdevice $DEVICE 

and the test will be conducted on that block device.
User should note, that testing like this will likely **corrupt any file system or data** stored on that device, so usage with caution is advised.
Also, some operations that doens't make sense for rawdevice testing are disabled and will only return OK status without doing anything (delete, soft/hard link, truncate, rename).