### PR TITLE
Adding random discard to list of available ops

### DIFF
--- a/common.py
+++ b/common.py
@@ -34,7 +34,7 @@ class rq:
     TRUNCATE = 9
     REMOUNT = 10
     READDIR = 11
-
+    RANDOM_DISCARD = 12
 
 # file size can either be fixed or exponential random distribution
 

--- a/fsop.py
+++ b/fsop.py
@@ -768,7 +768,7 @@ class FSOPCtx:
                 offset = os.lseek(fd, self.random_seek_offset(file_size - record_size), 0)
  
                 if self.verbosity & 0x20000:
-                    self.log.debug('random discard off %u size %u' % (off, record_size))
+                    self.log.debug('random discard off %u size %u' % (offset, record_size))
                 args = struct.pack('QQ', offset, record_size)
                 ioctl(fd, BLKDISCARD, args, 0)
                 count = record_size

--- a/fsop.py
+++ b/fsop.py
@@ -10,6 +10,8 @@ import random_buffer
 import numpy  # for gaussian distribution
 import subprocess
 import mmap
+import struct
+from fcntl import ioctl
 
 # my modules
 import common
@@ -38,7 +40,8 @@ class FSOPCtx:
          "rename":          rq.RENAME,
          "truncate":        rq.TRUNCATE,
          "remount":         rq.REMOUNT,
-         "readdir":         rq.READDIR
+         "readdir":         rq.READDIR,
+         "random_discard":  rq.RANDOM_DISCARD
     }
     
     opcode_to_opname = {
@@ -53,7 +56,8 @@ class FSOPCtx:
          rq.RENAME:         "rename",
          rq.TRUNCATE:       "truncate",
          rq.REMOUNT:        "remount",
-         rq.READDIR:        "readdir"
+         rq.READDIR:        "readdir",
+         rq.RANDOM_DISCARD: "random_discard"
     }
 
     # for gaussian distribution with moving mean, we need to remember simulated time
@@ -104,6 +108,7 @@ class FSOPCtx:
             rq.TRUNCATE:    self.op_truncate,
             rq.REMOUNT:     self.op_remount,
             rq.READDIR:     self.op_readdir,
+            rq.RANDOM_DISCARD: self.op_random_discard,
             }
         if self.params.random_distribution != common.FileAccessDistr.uniform:
             self.log.info('velocity=%f, stddev=%f, center=%f' % (self.velocity, self.params.gaussian_stddev, self.center))
@@ -737,7 +742,55 @@ class FSOPCtx:
             else:
                 return self.scallerr('rename', fn, e)
         return OK
-
+        
+    def op_random_discard(self):
+        if self.params.rawdevice == None:
+            return OK        
+        c = self.ctrs
+        fd = FD_UNDEFINED
+        fn = self.gen_random_fn()
+        BLKDISCARD =  0x12 << (4*2) | 119 # command for iocrl
+        try:
+            fd = os.open(fn, os.O_WRONLY)
+            file_size = self.get_file_size(fd)
+            target_size = self.random_file_size()
+            
+            if target_size > file_size:
+                target_size = file_size
+            if self.verbosity & 0x20000:
+                self.log.debug('randwrite %s size %u' % (fn, target_size))                
+            total_count = 0        
+            while total_count < target_size:
+                record_size = self.random_record_size()
+                if record_size + total_count > target_size:
+                    record_size = target_size - total_count
+               #Offset should be at least one record size away from end of file
+                offset = os.lseek(fd, self.random_seek_offset(file_size - record_size), 0)
+ 
+                if self.verbosity & 0x20000:
+                    self.log.debug('random discard off %u size %u' % (off, record_size))
+                args = struct.pack('QQ', offset, record_size)
+                ioctl(fd, BLKDISCARD, args, 0)
+                count = record_size
+                if self.verbosity & 0x20000:
+                    self.log.debug('random discard count %u record size %u' % (count, record_size))
+                total_count += count
+                c.randdiscard_requests += 1
+                c.randdiscard_bytes += total_count
+            c.have_randomly_discarded += 1
+        except OSError as e:
+            self.try_to_close(fd, fn)        
+            if e.errno == errno.ENOENT:
+                c.e_file_not_found += 1
+            elif e.errno == errno.ENOSPC or e.errno == errno.EDQUOT:
+                c.e_no_space += 1
+            elif e.errno == errno.ESTALE and self.params.tolerate_stale_fh:
+                c.e_stale_fh += 1
+                return NOTOK
+            else:
+                return self.scallerr('random discard', fn, e, fd=fd)
+        self.try_to_close(fd, fn)
+        return OK
 
     # unmounting is so risky that we shouldn't try to figure it out
     # make the user tell us the entire mount command

--- a/fsop_counters.py
+++ b/fsop_counters.py
@@ -17,6 +17,7 @@ class FSOPCounters:
         self.have_truncated = 0
         self.have_remounted = 0
         self.have_readdir = 0
+        self.have_randomly_discarded = 0
         
         # throughput counters
         self.read_requests = 0
@@ -27,6 +28,8 @@ class FSOPCounters:
         self.write_bytes = 0
         self.randwrite_requests = 0
         self.randwrite_bytes = 0
+        self.randdiscard_requests = 0
+        self.randdiscard_bytes = 0
         self.fsyncs = 0
         self.fdatasyncs = 0
         self.dirs_created = 0
@@ -61,6 +64,7 @@ class FSOPCounters:
         total.have_truncated        += self.have_truncated
         total.have_remounted        += self.have_remounted
         total.have_readdir          += self.have_readdir
+        total.have_randomly_discarded += self.have_randomly_discarded        
         
         # throughput counters
         total.read_requests         += self.read_requests
@@ -71,6 +75,8 @@ class FSOPCounters:
         total.write_bytes           += self.write_bytes
         total.randwrite_requests    += self.randwrite_requests
         total.randwrite_bytes       += self.randwrite_bytes
+        total.randdiscard_requests    += self.randdiscard_requests
+        total.randdiscard_bytes       += self.randdiscard_bytes
         total.fsyncs                += self.fsyncs
         total.fdatasyncs            += self.fdatasyncs
         total.dirs_created          += self.dirs_created
@@ -126,6 +132,8 @@ class FSOPCounters:
             ('write_bytes', self.write_bytes),
             ('randwrite_requests', self.randwrite_requests),
             ('randwrite_bytes', self.randwrite_bytes),
+            ('randdiscard_requests', self.randdiscard_requests),
+            ('randdiscard_bytes', self.randdiscard_bytes),
             ('fsyncs', self.fsyncs),
             ('fdatasyncs', self.fdatasyncs),
             ('dirs_created', self.dirs_created),


### PR DESCRIPTION
Adding random discard to list of available ops

This operation works similarly to random_write: determine target size, random offset, block size and issue IO.
Instead of writing data, the operation will issue this ioctl

ioctl(fd, BLKDISCARD, args, 0)
* fd: file descriptor
* BLKDISCARD: discard flag, i.e. 0x12 << (4*2) | 119
* args: struct containing offset and record size packaged as two unsigned long longs (args = struct.pack('QQ', offset, record_size))
* 0: mutate_flag

**Warning:** since this is raw, uncontrolled, direct discard it will corrupt any data or file systems stored on the device. Use with caution and only on devices that don't contain any important data.
Random discard operation is available only for rawdevice mode, attempts to run it in file system mode will have no effect.

Signed-off-by: Samuel Petrovic <spetrovi@redhat.com>