### PR TITLE
Test distributed fs

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,23 +238,12 @@ Sequential read. Will issue read IOs with given random block size (record size)
 
 Random discard. Will issue discard requests with given random block size (record size) via ioctl. Blocks to discard will be selected randomly similarly to random_write or random_read. Only available for rawdevice mode. Attempts to use this with file system mode results in no discards issued. **Warning**: Randomly discarding blocks on a device WILL corrupt any data or file systems present on that device. Make sure you're using testing device that doesn't contain anything important.
 
-## Future enhancements
+# how to test
 
-- logging - is a bit chaotic, done differently in different places, too many log files,
-should be simple and user-controllable while the test is running.
+you can run regtest.sh to exercise the code, this is highly recommended if you make changes.  This script should be updated
+to run any unit tests, with the least complex , quickest ones first.
 
-- make remounts work with multiple threads on a host
+# Future enhancements
 
-- allow mountpoint per process 
--- to simulate large client populations
--- to support block storage tests
+Use github issues to request or propose any future enhancements
 
-- extend number of filesystem operations
-
-- dynamic parameter adjustment - want to be able to change parameters while the test is running (to see how the
-  filesystem responds to major expansion/contraction, for example, or to see how different workload mixes impact the
-  filesystem without having to run a whole new test.
-
-- compression control - want to be able to specify buffers with different levels of compressibility
-
-- elastic search - import JSON results into Elastic Search so we can visualize results in Grafana

--- a/regtest.sh
+++ b/regtest.sh
@@ -10,6 +10,7 @@ logf='not-here'
 # export PYTHON_PROG=/usr/bin/python
 PY=${PYTHON_PROG:-/usr/bin/python3}
 sudo systemctl start sshd
+# ASSUMPTION: ssh localhost works without a password (you must set this up)
 
 # both of these scripts take a command string (in quotes) as param 1
 
@@ -74,3 +75,8 @@ chk "./fs-drift.py --duration 10 --max-record-size-kb 1 --max-file-size-kb 1 --d
 
 #Normal fs-drift usage (except the duration)
 chk "./fs-drift.py --duration 10 --response-times True --max-record-size-kb 4 --max-file-size-kb 4096 --threads 8 --max-files 10 --report-interval 1 --random-distribution gaussian --mean-velocity 10.0 --directIO True"
+
+# distributed filesystem usage
+ln -svf fs-drift-remote.py /usr/local/bin/
+chk "./fs-drift.py --host-set localhost --response-times True --duration 10 --report-interval 1 --threads 4"
+


### PR DESCRIPTION
Since distributed filesystems are an important use case for fs-drift, I wanted to include this in the regression test script.  I also updated documentation to describe how to run regression test and removed futures (can be handled in github issues).