### PR TITLE
Feature recordsize control

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,16 +120,16 @@ we can utilize more than 1 CPU core per host. But all subprocesses are just runn
 
 * --max-file-size-kb
 
-[Default: **10**] Set a limit on maximum file size in KB. File size is randomly generated and can be much less than this.
+[Default: **10**] Set a limit on maximum file size in KiB. File size is randomly generated and can be much less than this.
 
 
 * --max-record-size-kb
 
-[Default: **1**] Set a limit on maximum record size in KB. Record (I/O transfer) size is randomly generated and can be much less than this. Deprecated, use --record-size instead.
+[Default: **None**] Set a limit on maximum record size in KiB. Record (I/O transfer) size is randomly generated and can be much less than this. Deprecated, use --record-size instead. However, when set, this option will override --record-size, for compatibility reasons. Expected values: positive integer.
 
 * --record-size
 
-[Default: **4k**] Set a record size of either fixed value (4k) or range (1k:64k) for random record size. This parameter accepts units [b, k, m, g]. If no units specified, its treated as bytes. When using directIO, the value will be rounded to nearest 4kb and values less than 4kb will be increased to 4kb.
+[Default: **4k**] Set a record size of either fixed value (4k) or range (1k:64k) for random record size. This parameter accepts units [b, k, m, g]. If no units specified, input is treated as bytes. Specified units [k, m, g] are treated as KiB, MiB and GiB, respectively. When using directIO, the value will be rounded to nearest multiple of 4Kib.
 
 * --fsync-pct
 

--- a/README.md
+++ b/README.md
@@ -238,23 +238,12 @@ Sequential read. Will issue read IOs with given random block size (record size)
 
 Random discard. Will issue discard requests with given random block size (record size) via ioctl. Blocks to discard will be selected randomly similarly to random_write or random_read. Only available for rawdevice mode. Attempts to use this with file system mode results in no discards issued. **Warning**: Randomly discarding blocks on a device WILL corrupt any data or file systems present on that device. Make sure you're using testing device that doesn't contain anything important.
 
-## Future enhancements
+# how to test
 
-- logging - is a bit chaotic, done differently in different places, too many log files,
-should be simple and user-controllable while the test is running.
+you can run regtest.sh to exercise the code, this is highly recommended if you make changes.  This script should be updated
+to run any unit tests, with the least complex , quickest ones first.
 
-- make remounts work with multiple threads on a host
+# Future enhancements
 
-- allow mountpoint per process 
--- to simulate large client populations
--- to support block storage tests
+Use github issues to request or propose any future enhancements
 
-- extend number of filesystem operations
-
-- dynamic parameter adjustment - want to be able to change parameters while the test is running (to see how the
-  filesystem responds to major expansion/contraction, for example, or to see how different workload mixes impact the
-  filesystem without having to run a whole new test.
-
-- compression control - want to be able to specify buffers with different levels of compressibility
-
-- elastic search - import JSON results into Elastic Search so we can visualize results in Grafana

--- a/README.md
+++ b/README.md
@@ -125,8 +125,11 @@ we can utilize more than 1 CPU core per host. But all subprocesses are just runn
 
 * --max-record-size-kb
 
-[Default: **1**] Set a limit on maximum record size in KB. Record (I/O transfer) size is randomly generated and can be much less than this.
+[Default: **1**] Set a limit on maximum record size in KB. Record (I/O transfer) size is randomly generated and can be much less than this. Deprecated, use --record-size instead.
 
+* --record-size
+
+[Default: **4k**] Set a record size of either fixed value (4k) or range (1k:64k) for random record size. This parameter accepts units [b, k, m, g]. If no units specified, its treated as bytes. When using directIO, the value will be rounded to nearest 4kb and values less than 4kb will be increased to 4kb.
 
 * --fsync-pct
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ we can utilize more than 1 CPU core per host. But all subprocesses are just runn
 
 [Default: **1**] Set a limit on maximum record size in KB. Record (I/O transfer) size is randomly generated and can be much less than this.
 
+* --record-size
+
+[Default: **4k**] Set a record size of either fixed value (4k) or range (1k:64k) for random record size. This parameter accepts units [b, k, m, g]. If no units specified, its treated as bytes. When using directIO, the value will be rounded to nearest 4kb and values less than 4kb will be increased to 4kb.
 
 * --fsync-pct
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ last parameter in the command. This allows fs-drift to do the unmount operation 
 
 * --directIO
 
-[Default: **False**] If True, fs-drift will use flag O_DIRECT when opening files. All the issued IOs will be alligned to 4KB, i.e. record size and file size smaller than 4KB will be upscaled to 4KB.
+[Default: **False**] If True, fs-drift will use flag O_DIRECT when opening files. All the issued IOs will be alligned to 4KiB, i.e. record size and file size smaller than 4KiB will be upscaled to 4KiB. Other inputed sizes will be rounded to the nearest 4KiB size.
 
 
 * --rawdevice

--- a/fsop.py
+++ b/fsop.py
@@ -116,9 +116,9 @@ class FSOPCtx:
         if self.params.random_distribution != common.FileAccessDistr.uniform:
             self.log.info('velocity=%f, stddev=%f, center=%f' % (self.velocity, self.params.gaussian_stddev, self.center))
 
-        if self.params.directIO and self.params.max_record_size_kb < 4:
-            self.log.debug('record size too low for directIO, raising to 4KiB')        
-            self.params.max_record_size_kb = 4
+#        if self.params.directIO and self.params.max_record_size_kb < 4:
+#            self.log.debug('record size too low for directIO, raising to 4KiB')        
+#            self.params.max_record_size_kb = 4
 
         if self.params.directIO and self.params.max_file_size_kb < 4:
             self.log.debug('file size too low for directIO, raising to 4KiB')        
@@ -273,14 +273,15 @@ class FSOPCtx:
 
 
     def random_record_size(self):
-        max_size = min(self.params.max_record_size_kb, self.params.max_file_size_kb)
-        min_size = 1
-        if self.params.directIO:
-            min_size = 4096
-        recsz = random.randint(min_size, max_size * BYTES_PER_KiB)
+        #In case user inputs range, do random file size
+        if isinstance(self.params.record_size, tuple):
+            recsz = random.randint(self.params.record_size[0], self.params.record_size[1])    
+        else:
+            recsz = self.params.record_size
         if self.params.directIO:
             return (recsz // 4096) * 4096
         return recsz
+
 
 
     def random_segment_size(self, filesz):

--- a/opts.py
+++ b/opts.py
@@ -11,9 +11,9 @@ from argparse import ArgumentParser
 
 from common import OK, NOTOK, FsDriftException, FileAccessDistr, USEC_PER_SEC, BYTES_PER_KiB
 from common import FileAccessDistr2str
-from parser_data_types import boolean, positive_integer, non_negative_integer, bitmask
+from parser_data_types import boolean, positive_integer, non_negative_integer, bitmask, positive_integer_or_None
 from parser_data_types import positive_float, non_negative_float, positive_percentage
-from parser_data_types import host_set, file_access_distrib
+from parser_data_types import host_set, file_access_distrib, size_or_range
 from parser_data_types import FsDriftParseException, TypeExc
 
 
@@ -22,25 +22,6 @@ def getenv_or_default(var_name, var_default):
     if v == None:
         v = var_default
     return v
-
-#If the input is g or G, multiply by 1024*1024*1024
-#If the input is m or M, multiply by 1024*1024
-#If the input is k, K or unspecified, multiply by 1024
-#If the input is b or B, return as is
-def size_unit_to_bytes(v):
-    try:
-        if 'g' in v.lower():
-            return int(v[:-1]) * BYTES_PER_KiB * BYTES_PER_KiB * BYTES_PER_KiB
-        elif 'm' in v.lower():
-            return int(v[:-1]) * BYTES_PER_KiB * BYTES_PER_KiB
-        elif 'k' in v.lower():
-            return int(v[:-1]) * BYTES_PER_KiB
-        elif 'b' in v.lower():
-            return int(v[:-1])
-        else:
-            return int(v)
-    except ValueError:
-        raise TypeExc('valid size expected: [b, k, m, g], not ', v)
 
 # command line parameter variables here
 
@@ -64,8 +45,8 @@ class FsDriftOpts:
         self.duration = 1
         self.max_files = 200
         self.max_file_size_kb = 10
-        self.max_record_size_kb = 1
-        self.record_size = '4k'        
+        self.max_record_size_kb = None
+        self.record_size = 4096
         self.fdatasync_probability_pct = 10
         self.fsync_probability_pct = 20
         self.levels = 2
@@ -112,8 +93,8 @@ class FsDriftOpts:
             ('threads', self.threads),
             ('test duration', self.duration),
             ('maximum file count', self.max_files),
-            ('maximum file size (KB)', self.max_file_size_kb),
-            ('maximum record size (KB)', self.max_record_size_kb),
+            ('maximum file size (KiB)', self.max_file_size_kb),
+            ('maximum record size (KiB)', self.max_record_size_kb),
             ('record size ', self.record_size),
             ('fsync probability pct', self.fsync_probability_pct),
             ('fdatasync probability pct', self.fdatasync_probability_pct),
@@ -186,8 +167,8 @@ def assure_block_alignment(size):
     if size < 4 * BYTES_PER_KiB:
         print('size too low for directIO, raising to 4KiB')    
         return 4 * BYTES_PER_KiB
-    return size
-
+    return 4 * BYTES_PER_KiB * round(size / (4 * BYTES_PER_KiB))
+    
 def resolve_size(size_input, directIO):
     if ':' not in size_input:
         size = size_unit_to_bytes(size_input)
@@ -229,17 +210,17 @@ def parseopts(cli_params=sys.argv[1:]):
     add('--max-files', help='maximum number of files to access',
             type=positive_integer, 
             default=o.max_files)
-    add('--max-file-size-kb', help='maximum file size in KB',
+    add('--max-file-size-kb', help='maximum file size in KiB',
             type=positive_integer, 
             default=o.max_file_size_kb)
     add('--pause-between-ops', help='delay between ops in microsec',
             type=non_negative_integer,
             default=o.pause_between_ops)
-    add('--max-record-size-kb', help='maximum read/write size in KB. Deprecated, use --record-size instead',
+    add('--max-record-size-kb', help='maximum read/write size in KiB. Deprecated, use --record-size instead',
             type=positive_integer, 
             default=o.max_record_size_kb)
-    add('--record-size', help='read/write record size. If no units specified, treated like B. For range, enter two values separated by ":". Eg. 4:64',
-            type=str, 
+    add('--record-size', help='read/write record size. If no units specified, treated like B. Other units: k, m, g. For range, enter two values separated by ":". Eg. 4:64',
+            type=size_or_range, 
             default=o.record_size)            
     add('--fdatasync-pct', help='probability of fdatasync after write',
             type=positive_percentage, 
@@ -307,8 +288,11 @@ def parseopts(cli_params=sys.argv[1:]):
     o.duration = args.duration
     o.max_files = args.max_files
     o.max_file_size_kb = args.max_file_size_kb
-    o.record_size = resolve_size(args.record_size, args.directIO)
-    if isinstance(o.record_size, tuple):
+    o.record_size = args.record_size
+    if args.max_record_size_kb:
+        o.record_size = (1, args.max_record_size_kb * BYTES_PER_KiB)
+        o.max_record_size_kb = args.max_record_size_kb
+    elif isinstance(o.record_size, tuple):
         o.max_record_size_kb = o.record_size[-1] // BYTES_PER_KiB
     else:
         o.max_record_size_kb = o.record_size // BYTES_PER_KiB
@@ -317,7 +301,13 @@ def parseopts(cli_params=sys.argv[1:]):
     o.levels = args.levels
     o.subdirs_per_dir = args.dirs_per_level
     o.incompressible = args.incompressible
-    o.directIO = args.directIO    
+    o.directIO = args.directIO
+    if o.directIO:
+        o.max_record_size_kb = assure_block_alignment(o.max_record_size_kb * BYTES_PER_KiB) // BYTES_PER_KiB
+        if isinstance(o.record_size, tuple):
+            o.record_size = (assure_block_alignment(o.record_size[0]), assure_block_alignment(o.record_size[1]))
+        else:
+            o.record_size = assure_block_alignment(o.record_size)     
     o.rawdevice = args.rawdevice        
     o.pause_between_ops = args.pause_between_ops
     o.pause_secs = o.pause_between_ops / float(USEC_PER_SEC)
@@ -391,13 +381,9 @@ def parse_yaml(options, input_yaml_file):
             elif k == 'pause_between_ops':
                 options.pause_between_ops = non_negative_integer(v)
             elif k == 'max_record_size_kb':
-                options.max_record_size_kb = positive_integer(v)
+                options.max_record_size_kb = positive_integer_or_None(v)
             elif k == 'record_size':
-                if ':' in v:
-                    low_bound, high_bound = v.split(':')
-                    options.record_size = (size_unit_to_bytes(low_bound), size_unit_to_bytes(high_bound))
-                else:
-                    options.record_size = positive_integer(size_unit_to_bytes(v))                          
+                options.record_size = size_or_range(v)
             elif k == 'fdatasync_pct':
                 options.fdatasync_probability_pct = non_negative_integer(v)
             elif k == 'fsync_pct':
@@ -413,7 +399,7 @@ def parse_yaml(options, input_yaml_file):
             elif k == 'incompressible':
                 options.incompressible = boolean(v)
             elif k == 'directIO':
-                options.directIO = boolean(v)                
+                options.directIO = boolean(v)
             elif k == 'rawdevice':
                 options.rawdevice = v                    
             elif k == 'random_distribution':
@@ -434,6 +420,19 @@ def parse_yaml(options, input_yaml_file):
                 options.launch_as_daemon = boolean(v)
             else:
                 raise FsDriftParseException('unrecognized parameter name %s' % k)
+        if options.max_record_size_kb:
+            options.record_size = (1, options.max_record_size_kb * BYTES_PER_KiB)
+            options.max_record_size_kb = options.max_record_size_kb
+        elif isinstance(options.record_size, tuple):
+            options.max_record_size_kb = options.record_size[-1] // BYTES_PER_KiB
+        else:
+            options.max_record_size_kb = options.record_size // BYTES_PER_KiB
+        if options.directIO:
+            options.max_record_size_kb = assure_block_alignment(options.max_record_size_kb * BYTES_PER_KiB) // BYTES_PER_KiB
+            if isinstance(options.record_size, tuple):
+                options.record_size = (assure_block_alignment(options.record_size[0]), assure_block_alignment(options.record_size[1]))
+            else:
+                options.record_size = assure_block_alignment(options.record_size)
     except TypeExc as e:
         emsg = 'YAML parse error for key "%s" : %s' % (k, str(e))
         raise FsDriftParseException(emsg)
@@ -501,16 +500,16 @@ if __name__ == "__main__":
             fn = '/tmp/sample_parse.yaml'
             with open(fn, 'w') as f:
                 w = lambda s: f.write(s + '\n')
-                w('top: /tmp')
+                w('top: /var/tmp')
                 w('output_json: /var/tmp/x.json')
                 w('workload_table: /var/tmp/x.csv')
                 w('duration: 60')
                 w('threads: 30')
                 w('max_files: 10000')
-                w( 'max_file_size_kb: 1000000')
+                w('max_file_size_kb: 1000000')
                 w('pause_between_ops: 100')
-                w('max_record_size_kb: 4096')
-                w('record_size: 4k')                
+                w('max_record_size_kb: None')
+                w('record_size: 4096')                
                 w('fdatasync_pct: 2')
                 w('fsync_pct: 3')
                 w('levels: 4')
@@ -530,9 +529,9 @@ if __name__ == "__main__":
 
             p = self.params
             parse_yaml(p, fn)
-            assert(p.top_directory == '/tmp')
-            assert(p.network_shared_path == '/tmp/network-shared')
-            assert(p.stop_file_path == '/tmp/network-shared/stop-file.tmp')
+            assert(p.top_directory == '/var/tmp')
+            assert(p.network_shared_path == '/var/tmp/network-shared')
+            assert(p.stop_file_path == '/var/tmp/network-shared/stop-file.tmp')
             assert(p.output_json == '/var/tmp/x.json')
             assert(p.workload_table == '/var/tmp/x.csv')
             assert(p.duration == 60)
@@ -540,8 +539,8 @@ if __name__ == "__main__":
             assert(p.max_files == 10000)
             assert(p.max_file_size_kb == 1000000)
             assert(p.pause_between_ops == 100)
-            assert(p.max_record_size_kb == 4096)
-            assert(p.record_size == 4096)            
+            assert(p.max_record_size_kb == 4)
+            assert(p.record_size == 4096)
             assert(p.fdatasync_probability_pct == 2)
             assert(p.fsync_probability_pct == 3)
             assert(p.levels == 4)

--- a/opts.py
+++ b/opts.py
@@ -26,6 +26,15 @@ def getenv_or_default(var_name, var_default):
 # command line parameter variables here
 
 class FsDriftOpts:
+    def derive_paths(self):
+        self.starting_gun_path     = os.path.join(self.network_shared_path,'starting-gun.tmp')
+        self.stop_file_path        = os.path.join(self.network_shared_path,'stop-file.tmp')
+        self.param_pickle_path     = os.path.join(self.network_shared_path,'params.pickle')
+        self.rsptime_path          = os.path.join(self.network_shared_path,'host-%s_thrd-%s_rsptimes.csv')
+        self.abort_path            = os.path.join(self.network_shared_path,'abort.tmp')
+        self.pause_path            = os.path.join(self.network_shared_path,'pause.tmp')
+        self.checkerflag_path      = os.path.join(self.network_shared_path,'checkered_flag.tmp')
+
     def __init__(self):
         self.input_yaml = None
         self.output_json_path = None  # filled in later
@@ -279,15 +288,7 @@ def parseopts(cli_params=sys.argv[1:]):
     # some fields derived from user inputs
 
     o.network_shared_path = os.path.join(o.top_directory, 'network-shared')
-
-    nsjoin = lambda fn : os.path.join(o.network_shared_path, fn)
-    o.starting_gun_path     = nsjoin('starting-gun.tmp')
-    o.stop_file_path        = nsjoin('stop-file.tmp')
-    o.param_pickle_path     = nsjoin('params.pickle')
-    o.rsptime_path          = nsjoin('host-%s_thrd-%s_rsptimes.csv')
-    o.abort_path            = nsjoin('abort.tmp')
-    o.pause_path            = nsjoin('pause.tmp')
-    o.checkerflag_path      = nsjoin('checkered_flag.tmp')
+    o.derive_paths()
 
     #o.remote_pgm_dir = os.path.dirname(sys.argv[0])
     #if o.remote_pgm_dir == '.':
@@ -321,6 +322,8 @@ def parse_yaml(options, input_yaml_file):
                 raise FsDriftParseException('cannot specify YAML input file from within itself!')
             elif k == 'top':
                 options.top_directory = v
+                options.network_shared_path = os.path.join(v, 'network-shared')
+                options.derive_paths()
             elif k == 'output_json':
                 options.output_json = v
             elif k == 'workload_table':
@@ -470,6 +473,8 @@ if __name__ == "__main__":
             p = self.params
             parse_yaml(p, fn)
             assert(p.top_directory == '/tmp')
+            assert(p.network_shared_path == '/tmp/network-shared')
+            assert(p.stop_file_path == '/tmp/network-shared/stop-file.tmp')
             assert(p.output_json == '/var/tmp/x.json')
             assert(p.workload_table == '/var/tmp/x.csv')
             assert(p.duration == 60)

--- a/regtest.sh
+++ b/regtest.sh
@@ -109,14 +109,14 @@ chk "./fs-drift.py"
 chk "./fs-drift.py --random-distribution gaussian"
 
 #Check directIO
-chk "./fs-drift.py --duration 5 --max-record-size-kb 4 --max-file-size-kb 32 --directIO True"
+chk "./fs-drift.py --duration 5 --record-size 4k --max-file-size-kb 32 --directIO True"
 #Check if auto-alignment works even with bad values
-chk "./fs-drift.py --duration 10 --max-record-size-kb 1 --max-file-size-kb 1 --directIO True"
+chk "./fs-drift.py --duration 10 --record-size 1k --max-file-size-kb 1 --directIO True"
 
 #Normal fs-drift usage (except the duration)
 rm -rf /var/tmp/mydir
 mkdir /var/tmp/mydir
-chk "./fs-drift.py --top /var/tmp/mydir --duration 10 --response-times True --max-record-size-kb 4 --max-file-size-kb 4096 --threads 8 --max-files 10 --report-interval 1 --random-distribution gaussian --mean-velocity 10.0 --directIO True --output-json /tmp/fs-drift-result.json"
+chk "./fs-drift.py --top /var/tmp/mydir --duration 10 --response-times True --record-size 4k --max-file-size-kb 4096 --threads 8 --max-files 10 --report-interval 1 --random-distribution gaussian --mean-velocity 10.0 --directIO True --output-json /tmp/fs-drift-result.json"
 export params_json_fn=/tmp/fs-drift-result.json
 chk "./compute-rates.py /var/tmp/mydir/network-shared"
 

--- a/regtest.sh
+++ b/regtest.sh
@@ -56,8 +56,6 @@ chk "$PY fsop.py"
 chk "$PY event.py"
 chk "$PY ssh_thread.py"
 chk "$PY random_buffer.py"
-chk "$PY worker_thread.py"
-chk "$PY invoke_process.py"
 
 chk "$PY opts.py -h > /tmp/o"
 chk "grep 'option' /tmp/o"
@@ -65,6 +63,31 @@ mkdir -p /tmp/x.d
 chk "$PY opts.py "
 chkfail "$PY opts.py --top /x"
 
+# now do an invalid test through YAML, should be rejected
+cat > /tmp/t.yaml <<EOF
+report-interval: a
+EOF
+chkfail "$PY ./opts.py --input-yaml /tmp/t.yaml"
+
+# now do valid test in YAML
+cat > /tmp/t2.yaml <<EOF
+duration: 5
+response_times: True
+max_record_size_kb: 16
+max_file_size_kb: 64
+threads: 4
+max_files: 2000
+report_interval: 1
+EOF
+chk "$PY ./opts.py --input-yaml /tmp/t2.yaml"
+
+# tests related to multi-threading
+
+chk "$PY worker_thread.py"
+chk "$PY invoke_process.py"
+
+# now for the actual benchmark
+chk "./fs-drift.py"
 
 # test program that computes rates from counters
 
@@ -110,6 +133,7 @@ chk "./fs-drift.py --duration 5 --max-record-size-kb 4 --max-file-size-kb 32 --d
 chk "./fs-drift.py --duration 10 --max-record-size-kb 1 --max-file-size-kb 1 --directIO True"
 
 #Normal fs-drift usage (except the duration)
+
 rm -rf /var/tmp/mydir
 mkdir /var/tmp/mydir
 chk "./fs-drift.py --top /var/tmp/mydir --duration 10 --response-times True --max-record-size-kb 4 --max-file-size-kb 4096 --threads 8 --max-files 10 --report-interval 1 --random-distribution gaussian --mean-velocity 10.0 --directIO True --output-json /tmp/fs-drift-result.json"

--- a/regtest.sh
+++ b/regtest.sh
@@ -13,7 +13,6 @@ logf='not-here'
 # if you want to use python v2,
 # export PYTHON_PROG=/usr/bin/python
 PY=${PYTHON_PROG:-/usr/bin/python3}
-sudo systemctl start sshd
 
 # both of these scripts take a command string (in quotes) as param 1
 
@@ -91,6 +90,7 @@ chk "./fs-drift.py"
 
 # test program that computes rates from counters
 
+echo "testing rate computation"
 rm -rf /tmp/fake-result
 mkdir /tmp/fake-result
 for hst in a b c ; do
@@ -132,7 +132,21 @@ chk "./fs-drift.py --duration 5 --max-record-size-kb 4 --max-file-size-kb 32 --d
 #Check if auto-alignment works even with bad values
 chk "./fs-drift.py --duration 10 --max-record-size-kb 1 --max-file-size-kb 1 --directIO True"
 
-#Normal fs-drift usage (except the duration)
+# distributed filesystem usage
+# if you want this part of test to run, 
+# you must set up softlink /usr/local/bin/fs-drift-remote.py 
+# to point to your development directory,
+# and you must enable password-less ssh to localhost in this account,
+# and you must enable sudo 
+
+if [ -x /usr/local/bin/fs-drift-remote.py ] ; then
+  # ASSUMPTION: ssh localhost works without a password (you must set this up)
+  sudo systemctl start sshd
+  ssh localhost pwd
+  chk "./fs-drift.py --host-set localhost --response-times True --duration 10 --report-interval 1 --threads 4"
+fi
+
+# Normal fs-drift usage (except the duration)
 
 rm -rf /var/tmp/mydir
 mkdir /var/tmp/mydir

--- a/regtest.sh
+++ b/regtest.sh
@@ -128,9 +128,9 @@ chk "./fs-drift.py"
 chk "./fs-drift.py --random-distribution gaussian"
 
 #Check directIO
-chk "./fs-drift.py --duration 5 --max-record-size-kb 4 --max-file-size-kb 32 --directIO True"
+chk "./fs-drift.py --duration 5 --record-size 4k --max-file-size-kb 32 --directIO True"
 #Check if auto-alignment works even with bad values
-chk "./fs-drift.py --duration 10 --max-record-size-kb 1 --max-file-size-kb 1 --directIO True"
+chk "./fs-drift.py --duration 10 --record-size 1k --max-file-size-kb 1 --directIO True"
 
 # distributed filesystem usage
 # if you want this part of test to run, 
@@ -150,5 +150,5 @@ fi
 
 rm -rf /var/tmp/mydir
 mkdir /var/tmp/mydir
-chk "./fs-drift.py --top /var/tmp/mydir --duration 10 --response-times True --max-record-size-kb 4 --max-file-size-kb 4096 --threads 8 --max-files 10 --report-interval 1 --random-distribution gaussian --mean-velocity 10.0 --directIO True --output-json /tmp/fs-drift-result.json"
+chk "./fs-drift.py --top /var/tmp/mydir --duration 10 --response-times True --record-size 4 --max-file-size-kb 4096 --threads 8 --max-files 10 --report-interval 1 --random-distribution gaussian --mean-velocity 10.0 --directIO True --output-json /tmp/fs-drift-result.json"
 params_json_fn=/tmp/fs-drift-result.json ./compute-rates.py /var/tmp/mydir/network-shared


### PR DESCRIPTION
Adding better record size control by introducing --record-size option
Features:
*Supports units [b,k,m,g]
*Supports rannges (e.g. 4k:64k)

Deprecating --max-record-size-kb